### PR TITLE
Add pvm script to activate the shell environment

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -212,6 +212,17 @@ namespace "build" do
   task :ffi => ["#{ffi.prefix}/lib/libffi.dylib"]
 end
 
+directory "#{config.root}"
+directory "#{config.root}/bin"
+file "#{config.root}/bin/pvm" do
+  cp "bin/pvm", "#{config.root}/bin/pvm"
+end
+
+namespace "install" do
+  desc "Install pvm script"
+  task :pvm => ["#{config.root}/bin/pvm"]
+end
+
 desc "Build all of the things"
 task :build => ["build:openssl", "build:yaml", "build:ffi", "build:ruby"] do
   puts "All Done!"

--- a/bin/pvm
+++ b/bin/pvm
@@ -1,0 +1,28 @@
+#! /bin/bash
+#
+# Minimal version manager using environment variables.
+#
+# Everything uses bash substring replacement.  See
+# http://tldp.org/LDP/abs/html/string-manipulation.html#SUBSTRREPL00 for more
+# information.
+#
+# The substitutions used are:
+# %rv = Ruby, version, e.g. 1.9.3-p327
+# %gv = Gemset name, e.g. dev
+
+PVM_PATH="/opt/puppet/versions/bin:/opt/puppet/versions/ruby/%rv/bin:/opt/puppet/versions/ruby/%rv/gemsets/%gv/bin:/opt/puppet/versions/ruby/%rv/gemsets/global/bin:${PATH}"
+
+: ${PVM_RUBY_VERSION:=1.9.3-p327}
+: ${PVM_GEMSET:=dev}
+
+newpath="${PVM_PATH}"
+newpath="${newpath//%rv/$PVM_RUBY_VERSION}"
+newpath="${newpath//%gv/$PVM_GEMSET}"
+echo PVM_RUBY_VERSION="'${PVM_RUBY_VERSION}'"
+echo export PATH="'${newpath}'"
+echo export GEM_PATH="'/opt/puppet/versions/ruby/${PVM_RUBY_VERSION}/gemsets/global'"
+echo export GEM_HOME="'/opt/puppet/versions/ruby/${PVM_RUBY_VERSION}/gemsets/${PVM_GEMSET}'"
+
+if [ -z "$PVM_NO_PROMPT" ]; then
+  echo "PS1=\"(${PVM_RUBY_VERSION} ${PVM_GEMSET})\$PS1\""
+fi


### PR DESCRIPTION
Without this patch we have Ruby built and installed, but we don't have
an easy way to actually use the software in the new filesystem
hierarchy.

This patch addresses the problem by providing a small script that will
print out sh compatible shell code suitable for an `eval` statement.

For example:

```
$ which ruby
/usr/bin/ruby
$ eval `/opt/puppet/versions/bin/pvm`
(1.9.3-p327 dev)$ which ruby
/opt/puppet/versions/ruby/1.9.3-p327/bin/ruby
```

Note the prompt is changed as well to indicate the gemset and ruby
version currently activate in the shell environment.
